### PR TITLE
Update to CSRF-Token supporting client-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "interactive"
   ],
   "dependencies": {
-    "beam-client-node": "^0.3.0",
+    "beam-client-node": "^0.6.1",
     "beam-interactive-node": "^0.2.0",
     "fs-extra": "^0.26.5",
     "jquery": "^2.2.1",


### PR DESCRIPTION
We made some breaking changes in our API,

The latest version of beam-client-node is required to support these.
